### PR TITLE
Reverting old functionality of injecting different auth method

### DIFF
--- a/src/config/log.php
+++ b/src/config/log.php
@@ -40,6 +40,21 @@ return [
 
 	/*
 	|--------------------------------------------------------------------------
+	| Auth Method
+	|--------------------------------------------------------------------------
+	|
+	| If you are using any alternative packages for Authentication and User
+	| management then you can put in the appropriate function to get
+	| the currently logged in user.
+	|
+	| For example, if you are using Sentry, you would put Sentry::getUser()
+	| instead of Laravel's default which is Auth::user().
+	|
+	*/
+	'auth_method' => '\Auth::user',
+
+	/*
+	|--------------------------------------------------------------------------
 	| Action Icons
 	|--------------------------------------------------------------------------
 	|

--- a/src/models/Activity.php
+++ b/src/models/Activity.php
@@ -55,7 +55,7 @@ class Activity extends Eloquent {
 
 		if (config('log.auto_set_user_id'))
 		{
-			$user = \Auth::user();
+			$user = call_user_func(config('log.auth_method'));
 			$activity->user_id = isset($user->id) ? $user->id : null;
 		}
 


### PR DESCRIPTION
In Laravel 5.1 its no longer possible to inject the actual classes and methods to the config which is nice because the framework is getting less hacky.

I tried to overcome that by providing method as a string, and calling it using the call_user_func(). The solution might not be the cleanest, but it gets the job done - its possible to use other means of Authentication like Sentinel (https://github.com/cartalyst/sentinel).
