### PR TITLE
make ip_address writable through  parameter to allow rewrite in case of proxied IP addresses

### DIFF
--- a/src/Models/Activity.php
+++ b/src/Models/Activity.php
@@ -99,7 +99,7 @@ class Activity extends Eloquent {
 
 		//set developer flag
 		$activity->developer  = !is_null(Session::get('developer')) ? true : false;
-		$activity->ip_address = Request::getClientIp();
+		$activity->ip_address = isset($data['ipAddress']) ? $data['ipAddress'] : Request::getClientIp();
 		$activity->user_agent = isset($_SERVER['HTTP_USER_AGENT']) ? $_SERVER['HTTP_USER_AGENT'] : 'No UserAgent';
 		$activity->save();
 


### PR DESCRIPTION
In order to change the "Request::getClientIp()" feature, and use something else (X-Forwarded-For header for example) I have added the possibility to configure the ip_address by by add it in the $data['ipAddress'] parameter.