### PR TITLE
migration for indexes

### DIFF
--- a/src/migrations/2017_07_05_103000_alter_activity_log_table_add_index.php
+++ b/src/migrations/2017_07_05_103000_alter_activity_log_table_add_index.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AlterActivityLogTableAddIndex extends Migration {
+
+	/**
+	 * Run the migrations.
+	 *
+	 * @return void
+	 */
+	public function up()
+	{
+		Schema::table('activity_log', function($table)
+		{
+			$table->index(['content_id', 'content_type'], 'idx_content');
+			$table->index('user_id', 'user_id');
+		});
+	}
+
+	/**
+	 * Reverse the migrations.
+	 *
+	 * @return void
+	 */
+	public function down()
+	{
+		Schema::table('activity_log', function($table)
+		{
+			$table->dropIndex('idx_content');
+			$table->dropIndex('user_id');
+		});
+	}
+
+}


### PR DESCRIPTION
added indexes to speed up two most common searches: by user and content id-type. Otherwise those searches are really slow on big amount of data.